### PR TITLE
Injected/more coverage

### DIFF
--- a/SpareMe/components/injected.js
+++ b/SpareMe/components/injected.js
@@ -136,7 +136,7 @@ export const injectedJS = `(${String(function() {
                 // Alert React that the user unflagged an element
                 window.postMessage(JSON.stringify({
                     messageType: 'addTextToAPI',
-                    text : String(element.tagName === 'img' ?
+                    text : String(element.tagName === 'IMG' ?
                         element.alt :
                         element.innerText),
                         category: DEFAULT_CATEGORY
@@ -157,12 +157,20 @@ export const injectedJS = `(${String(function() {
     function hideElement(element) {
         element.classList.add(HIDDEN_CLASSNAME);
 
-        // Cascade class down to all children
-        for (var i = 0; i < element.children.length; i++) {
-            element.children.item(i).classList.add(HIDDEN_CLASSNAME);
+        if (element.tagName === 'IMG') {
+            element.oldSrc = element.src;
+
+            // We may want to host this image ourselves to ensure it's always available
+            element.src = "https://www.materialui.co/materialIcons/action/visibility_off_grey_24x24.png";
+
+            element.style.opacity = '0.5';
+            element.style.width = "auto";
+            element.style.height = 'auto';
+        } else {
+            element.style.color = 'transparent';
+            element.style.textShadow = '0 0 20px black';
         }
 
-        element.style.filter = 'blur(10px)';
         element.style.webkitUserSelect = 'none';
         element.addEventListener('click', onHiddenElementClick(element));
         configureLongPressActions(element)
@@ -171,8 +179,19 @@ export const injectedJS = `(${String(function() {
     function revealElement(element) {
         element.classList.remove(HIDDEN_CLASSNAME);
         element.classList.add(REVEALED_CLASSNAME);
+
+        if (element.tagName === 'IMG') {
+            element.src = element.oldSrc;
+            element.style.opacity = null;
+            element.style.width = null;
+            element.style.height = null;
+            element.style.border = null;
+        } else {
+            element.style.color = null;
+            element.style.textShadow = null;
+        }
+
         element.style.webkitUserSelect = 'auto';
-        element.style.filter = 'blur(0px)';
         window.revealedElement = element;
     }
 
@@ -290,7 +309,7 @@ export const injectedJS = `(${String(function() {
     }
 
     function analyzePage() {
-        var elements = document.body.querySelectorAll('p, a, li, h1, h2, h3, h4, span, div, font, b');
+        var elements = document.body.querySelectorAll('p, a, li, h1, h2, h3, h4, span, div, font, b, img');
         var predictionGroup = {};
         for (var i = 0; i < elements.length; i++) {
             var element = elements[i];
@@ -313,7 +332,7 @@ export const injectedJS = `(${String(function() {
             element.classList.add(INJECTED_CLASSNAME)
 
             // Map the added class name to the element's innerText
-            predictionGroup[addedClass] = String(element.tagName === 'img' ? element.alt : element.innerText)
+            predictionGroup[addedClass] = String(element.tagName === 'IMG' ? element.alt : element.innerText)
 
             // Send elements in groups of HTTP_BATCH_SIZE to React
             if (injectedClassCounter % HTTP_BATCH_SIZE == 0 || i == elements.length - 1) {

--- a/SpareMe/components/injected.js
+++ b/SpareMe/components/injected.js
@@ -22,6 +22,24 @@ export const injectedJS = `(${String(function() {
         document.addEventListener('message', onReactMessage);
         document.addEventListener('selectionchange', onSelection);
 
+        /* Listen for and process dynamically-added elements */
+        var observer = new MutationObserver(function(mutations) {
+                for (var i = 0; i < mutations.length; i++) {
+                    for (var j = 0; j < mutations[i].addedNodes.length; j++) {
+                        console.log(mutations[i].addedNodes[j])
+
+                        let addedNode = mutations[i].addedNodes[j];
+
+                        addedNode.querySelectorAll('*').forEach(function(element) {
+                            hideElement(element);
+                        })
+                    }
+                }
+        });
+
+        observer.observe(document, {attributes: false, childList: true, characterData: false, subtree:true});
+
+
         // Send tags to React for processing
         analyzePage();
     }
@@ -52,6 +70,10 @@ export const injectedJS = `(${String(function() {
             case 'hide':
                 let className = action['className'];
                 var element = document.getElementsByClassName(className)[0];
+
+                if (!element) {
+                    return;
+                }
 
                 // Only hide elements once :D
                 if (!isHidden(element) && !isRevealed(element)) {
@@ -174,7 +196,7 @@ export const injectedJS = `(${String(function() {
             element.style.objectPosition ="50% 50%";
 
         } else {
-            element.style.color = 'transparent';
+            element.style.setProperty('color', 'transparent', 'important');
             element.style.textShadow = '0 0 20px black';
         }
 
@@ -345,6 +367,11 @@ export const injectedJS = `(${String(function() {
                 }
             }
 
+            console.log("analyzing:")
+            console.log(element)
+
+            // document.addEventListener('load', (element) => {console.log("loaded:" + element); hideElement(element)}, false)
+
             // Add unique class so we can find this element later
             let addedClass = INJECTED_CLASSNAME + injectedClassCounter;
             injectedClassCounter += 1;
@@ -369,11 +396,11 @@ export const injectedJS = `(${String(function() {
     }
 
     function isHidden(element) {
-        return element.classList.contains(HIDDEN_CLASSNAME);
+        return element && element.classList.contains(HIDDEN_CLASSNAME);
     }
 
     function isRevealed(element) {
-        return element.classList.contains(REVEALED_CLASSNAME);
+        return element && element.classList.contains(REVEALED_CLASSNAME);
     }
 
 })})();` // JavaScript :)

--- a/SpareMe/components/injected.js
+++ b/SpareMe/components/injected.js
@@ -170,9 +170,10 @@ export const injectedJS = `(${String(function() {
             }
 
             // We may want to host this image ourselves to ensure it's always available
-            element.src = "https://www.materialui.co/materialIcons/action/visibility_off_grey_96x96.png";
-            element.style.width = "auto";
-            element.style.height = 'auto';
+            element.src = "https://www.materialui.co/materialIcons/action/visibility_off_grey_192x192.png";
+            element.style.objectFit = "contain"
+            element.style.objectPosition ="50% 50%";
+
         } else {
             element.style.color = 'transparent';
             element.style.textShadow = '0 0 20px black';
@@ -194,12 +195,12 @@ export const injectedJS = `(${String(function() {
         }
 
         if (element.tagName === 'IMG') {
+            // Reset all changed image properties
             element.style.visibility = "hidden"; // prevent image flashing
-            element.style.width = null;
-            element.style.height = null;
             element.src = element.oldSrc;
+            element.style.objectFit = null;
+            element.style.objectPosition = null;
             element.style.visibility = "visible" // prevent image flashing
-
         } else {
             element.style.color = null;
             element.style.textShadow = null;
@@ -207,8 +208,6 @@ export const injectedJS = `(${String(function() {
 
         element.style.webkitUserSelect = 'auto';
         window.revealedElement = element;
-        console.log("revealed element:")
-        console.log(element)
     }
 
     function configureLongPressActions(node) {

--- a/SpareMe/components/injected.js
+++ b/SpareMe/components/injected.js
@@ -112,8 +112,6 @@ export const injectedJS = `(${String(function() {
                     var elementsInRangeParent = selectionRange.commonAncestorContainer
                         .getElementsByClassName(INJECTED_CLASSNAME);
 
-                    console.log(elementsInRangeParent);
-
                     for (var i = 0, element; element = elementsInRangeParent[i]; i++) {
                         if (selection.containsNode(element, true)) {
                             hideElement(element);
@@ -145,7 +143,6 @@ export const injectedJS = `(${String(function() {
 
             case 'unflagIgnored':
                 var element = window.revealedElement;
-                console.log('unflagIgnored');
                 hideElement(element);
 
                 let img = element.getElementsByTagName("IMG")[0];
@@ -334,8 +331,6 @@ export const injectedJS = `(${String(function() {
                 if (element.firstChild != null && (element.firstChild.tagName === 'SPAN' || element.firstChild.tagName === 'DIV')) {
                     continue;
                 }
-            } else {
-                console.log('Found non-empty div/span');
             }
 
             // Add unique class so we can find this element later

--- a/SpareMe/components/injected.js
+++ b/SpareMe/components/injected.js
@@ -144,6 +144,8 @@ export const injectedJS = `(${String(function() {
             case 'unflagIgnored':
                 var element = window.revealedElement;
                 hideElement(element);
+                console.log("unflag ignored for ");
+                console.log(element);
 
                 let img = element.getElementsByTagName("IMG")[0];
                 if (img != null) {
@@ -179,17 +181,20 @@ export const injectedJS = `(${String(function() {
         element.style.webkitUserSelect = 'none';
         element.addEventListener('click', onHiddenElementClick(element));
         configureLongPressActions(element)
+
+        var children = element.children;
+
+        // If this node was revealed, check and hide any of its revealed children.
+        for (var i = 0; i < children.length; i++) {
+            if (isRevealed(children[i])) {
+                hideElement(children[i]);
+            }
+        }
     }
 
     function revealElement(element) {
         element.classList.remove(HIDDEN_CLASSNAME);
         element.classList.add(REVEALED_CLASSNAME);
-
-        // Recurse for img containers
-        let img = element.getElementsByTagName("IMG")[0];
-        if (img != null) {
-            revealElement(img);
-        }
 
         if (element.tagName === 'IMG') {
             // Reset all changed image properties
@@ -205,6 +210,11 @@ export const injectedJS = `(${String(function() {
 
         element.style.webkitUserSelect = 'auto';
         window.revealedElement = element;
+
+        // Recurse up for elements in containers
+        if (isHidden(element.parentElement)) {
+            revealElement(parentElement);
+        }
     }
 
     function configureLongPressActions(node) {
@@ -235,6 +245,8 @@ export const injectedJS = `(${String(function() {
     function onHiddenElementClick(element) {
         return function(event) {
             if (isHidden(element)) {
+                console.log("called onHiddenElementClick for ")
+                console.log(element);
                 /* Element must be revealed before allowing
                 its normal onclick to fire */
                 event.preventDefault();

--- a/SpareMe/components/injected.js
+++ b/SpareMe/components/injected.js
@@ -145,7 +145,15 @@ export const injectedJS = `(${String(function() {
 
             case 'unflagIgnored':
                 var element = window.revealedElement;
+                console.log('unflagIgnored');
                 hideElement(element);
+
+                let img = element.getElementsByTagName("IMG")[0];
+
+                if (img != null) {
+                    hideElement(img);
+                }
+
                 break;
 
             default:
@@ -161,9 +169,7 @@ export const injectedJS = `(${String(function() {
             element.oldSrc = element.src;
 
             // We may want to host this image ourselves to ensure it's always available
-            element.src = "https://www.materialui.co/materialIcons/action/visibility_off_grey_24x24.png";
-
-            element.style.opacity = '0.5';
+            element.src = "https://www.materialui.co/materialIcons/action/visibility_off_grey_96x96.png";
             element.style.width = "auto";
             element.style.height = 'auto';
         } else {
@@ -180,12 +186,19 @@ export const injectedJS = `(${String(function() {
         element.classList.remove(HIDDEN_CLASSNAME);
         element.classList.add(REVEALED_CLASSNAME);
 
+        // Recurse for img containers
+        let img = element.getElementsByTagName("IMG")[0];
+        if (img != null) {
+            revealElement(img);
+        }
+
         if (element.tagName === 'IMG') {
-            element.src = element.oldSrc;
-            element.style.opacity = null;
+            element.style.visibility = "hidden"; // prevent image flashing
             element.style.width = null;
             element.style.height = null;
-            element.style.border = null;
+            element.src = element.oldSrc;
+            element.style.visibility = "visible" // prevent image flashing
+
         } else {
             element.style.color = null;
             element.style.textShadow = null;
@@ -193,6 +206,8 @@ export const injectedJS = `(${String(function() {
 
         element.style.webkitUserSelect = 'auto';
         window.revealedElement = element;
+        console.log("revealed element:")
+        console.log(element)
     }
 
     function configureLongPressActions(node) {
@@ -309,7 +324,7 @@ export const injectedJS = `(${String(function() {
     }
 
     function analyzePage() {
-        var elements = document.body.querySelectorAll('p, a, li, h1, h2, h3, h4, span, div, font, b, img');
+        var elements = document.body.querySelectorAll('p, a, li, h1, h2, h3, h4, span, div, font, b, img, strong');
         var predictionGroup = {};
         for (var i = 0; i < elements.length; i++) {
             var element = elements[i];

--- a/SpareMe/components/injected.js
+++ b/SpareMe/components/injected.js
@@ -149,7 +149,6 @@ export const injectedJS = `(${String(function() {
                 hideElement(element);
 
                 let img = element.getElementsByTagName("IMG")[0];
-
                 if (img != null) {
                     hideElement(img);
                 }
@@ -166,7 +165,9 @@ export const injectedJS = `(${String(function() {
         element.classList.add(HIDDEN_CLASSNAME);
 
         if (element.tagName === 'IMG') {
-            element.oldSrc = element.src;
+            if (element.oldSrc == null) {
+                element.oldSrc = element.src;
+            }
 
             // We may want to host this image ourselves to ensure it's always available
             element.src = "https://www.materialui.co/materialIcons/action/visibility_off_grey_96x96.png";

--- a/SpareMe/components/injected.js
+++ b/SpareMe/components/injected.js
@@ -290,18 +290,18 @@ export const injectedJS = `(${String(function() {
     }
 
     function analyzePage() {
-        var elements = document.body.querySelectorAll('p, a, li, h1, h2, h3, h4, span, div');
+        var elements = document.body.querySelectorAll('p, a, li, h1, h2, h3, h4, span, div, font, b');
         var predictionGroup = {};
         for (var i = 0; i < elements.length; i++) {
-            var element = elements[i]
+            var element = elements[i];
 
-            // Discard divs and spans that wrap other HTML elements
             if (element.tagName === 'SPAN' || element.tagName === 'DIV') {
-                if (element.childElementCount != 0) {
+                // Discard divs and spans that wrap other HTML elements
+                if (element.firstChild != null && (element.firstChild.tagName === 'SPAN' || element.firstChild.tagName === 'DIV')) {
                     continue;
-                } else {
-                    console.log('Found non-empty div/span');
                 }
+            } else {
+                console.log('Found non-empty div/span');
             }
 
             // Add unique class so we can find this element later

--- a/SpareMe/ios/SpareMe/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/SpareMe/ios/SpareMe/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -1,6 +1,7 @@
 {
   "images" : [
     {
+<<<<<<< HEAD
       "size" : "20x20",
       "idiom" : "iphone",
       "filename" : "Icon-40.png",
@@ -13,6 +14,9 @@
       "scale" : "3x"
     },
     {
+=======
+      "idiom" : "iphone",
+>>>>>>> Code cleanup
       "size" : "29x29",
       "idiom" : "iphone",
       "filename" : "Icon-58.png",
@@ -47,12 +51,15 @@
       "idiom" : "iphone",
       "filename" : "Icon-180.png",
       "scale" : "3x"
+<<<<<<< HEAD
     },
     {
       "size" : "1024x1024",
       "idiom" : "ios-marketing",
       "filename" : "Icon-1024.png",
       "scale" : "1x"
+=======
+>>>>>>> Code cleanup
     }
   ],
   "info" : {

--- a/SpareMe/ios/SpareMe/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/SpareMe/ios/SpareMe/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -1,7 +1,6 @@
 {
   "images" : [
     {
-<<<<<<< HEAD
       "size" : "20x20",
       "idiom" : "iphone",
       "filename" : "Icon-40.png",
@@ -14,9 +13,6 @@
       "scale" : "3x"
     },
     {
-=======
-      "idiom" : "iphone",
->>>>>>> Code cleanup
       "size" : "29x29",
       "idiom" : "iphone",
       "filename" : "Icon-58.png",
@@ -51,15 +47,12 @@
       "idiom" : "iphone",
       "filename" : "Icon-180.png",
       "scale" : "3x"
-<<<<<<< HEAD
     },
     {
       "size" : "1024x1024",
       "idiom" : "ios-marketing",
       "filename" : "Icon-1024.png",
       "scale" : "1x"
-=======
->>>>>>> Code cleanup
     }
   ],
   "info" : {


### PR DESCRIPTION
### Hides more types of elements 
AC: mock the API to flag everything as hateful; go to Stormfront; almost everything should be hidden. If things still slip through, we can add them in a separate PR

### Dramatically speeds up blurring/the browsing experience as a whole
Removes the CSS `filter` property, because apparently it's very slow on mobile browsers. Who knew? 
- Hides images behind the "invisible" icon to avoid using `filter`. 

### Hides text on infinite scrolling pages
Before this, going to a dynamically-loaded site (like a Twitter feed) results in no elements being processed or blocked. 

Note that there may still be edge cases where some types of elements slip through. Please alert me if you find any 

Closes #110 #129 and #134